### PR TITLE
Bump agent/relay new version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ ARG BUILD_FROM
 FROM $BUILD_FROM
 
 # Copy init script, 8xFF relayer and agent binary
-RUN wget https://github.com/8xFF/atm0s-decentralized-home-assistant-proxy/releases/download/latest/agent-x86_64-unknown-linux-musl -O agent \
-    && wget https://github.com/8xFF/atm0s-decentralized-home-assistant-proxy/releases/download/latest/relayer-x86_64-unknown-linux-musl -O relayer
+RUN wget https://github.com/8xFF/atm0s-reverse-proxy/releases/download/latest/agent-x86_64-unknown-linux-musl -O agent \
+    && wget https://github.com/8xFF/atm0s-reverse-proxy/releases/download/latest/relayer-x86_64-unknown-linux-musl -O relayer
 RUN chmod 755 agent relayer
 
 COPY data/run.sh /

--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 A decentralized proxy for HA.
 
-![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
+![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
 
 This add-on aims to create an innovative decentralized relay server for HomeAssistant. The server allows contributions from anyone and provides a fast and optimized path between clients.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [i386-shield]: https://img.shields.io/badge/i386-yes-green.svg

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,6 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base:3.18
   amd64: ghcr.io/home-assistant/amd64-base:3.18
-  armhf: ghcr.io/home-assistant/armhf-base:3.18
   armv7: ghcr.io/home-assistant/armv7-base:3.18
   i386: ghcr.io/home-assistant/i386-base:3.18
 codenotary:

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: 8xFF HA relayer agent
-description: Decentralized HomeAssistant Proxy
-version: 0.1.7
+description: Decentralized Home Assistant Proxy
+version: 0.1.8
 slug: 8xff_ha_relayer
 init: false
 host_network: true
@@ -13,10 +13,12 @@ map:
 arch:
   - aarch64
   - amd64
+  - armhf
   - armv7
   - i386
 options:
-  connector_addr: 127.0.0.1:33333
+  # TODO: make server as list of contributing nodes 
+  connector_addr: ha.8xff.io:33333
   connector_protocol: tcp
   http_dest: 127.0.0.1:8080
   https_dest: 127.0.0.1:8443

--- a/config.yaml
+++ b/config.yaml
@@ -13,7 +13,6 @@ map:
 arch:
   - aarch64
   - amd64
-  - armhf
   - armv7
   - i386
 options:

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: 8xFF HA relayer agent
 description: Decentralized Home Assistant Proxy
-version: 0.1.8
+version: 0.2.0
 slug: 8xff_ha_relayer
 init: false
 host_network: true

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,3 @@
-# https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
 name: 8xFF's Home Assistant Add-ons
 url: 'https://github.com/8xFF/atm0s-decentralized-home-assistant-proxy/'
 maintainer: 8xFF Team


### PR DESCRIPTION
- Separate code of agent/relay to new repo: https://github.com/8xFF/atm0s-reverse-proxy
- Remove armhf support
- Change default server config of add-on to `ha.8xff.io`